### PR TITLE
Added a GoDoc Badge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![GoDoc](https://godoc.org/github.com/FogCreek/mini?status.svg)](https://godoc.org/github.com/FogCreek/mini)
+
 Mini is a simple [ini configuration file](http://en.wikipedia.org/wiki/INI_file) parser.
 
 The ini syntax supported includes:


### PR DESCRIPTION
I noticed that there's no link to the package documentation in the readme, so I've added a GoDoc badge (which links to GoDoc).

![screen shot 2015-02-21 at 22 36 35](https://cloud.githubusercontent.com/assets/2125849/6317456/2e73ef36-ba1a-11e4-9c59-9436f0727c65.png)

&mdash; @citruspi
